### PR TITLE
Rename package to nobleo_socketcan_bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.8)
-project(ros2_socketcan_bridge)
+project(nobleo_socketcan_bridge)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -37,7 +37,7 @@ target_link_libraries(socketcan_bridge_component fmt::fmt)
 
 rclcpp_components_register_node(
     socketcan_bridge_component
-    PLUGIN "ros2_socketcan_bridge::SocketCanBridgeNode"
+    PLUGIN "nobleo_socketcan_bridge::SocketCanBridgeNode"
     EXECUTABLE socketcan_bridge
 )
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright (C) 2024 Nobleo Technology B.V.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# ros2_socketcan_bridge
+# nobleo_socketcan_bridge
 
 This package provides functionality to expose CAN frames from SocketCAN to ROS2 topics.
 

--- a/include/nobleo_socketcan_bridge/socketcan_bridge.hpp
+++ b/include/nobleo_socketcan_bridge/socketcan_bridge.hpp
@@ -19,7 +19,7 @@ class Node;
 class Clock;
 }  // namespace rclcpp
 
-namespace ros2_socketcan_bridge
+namespace nobleo_socketcan_bridge
 {
 class SocketCanBridge
 {
@@ -61,4 +61,4 @@ can_frame from_msg(const can_msgs::msg::Frame & msg);
 can_msgs::msg::Frame to_msg(const can_frame & frame);
 ;
 
-}  // namespace ros2_socketcan_bridge
+}  // namespace nobleo_socketcan_bridge

--- a/include/nobleo_socketcan_bridge/socketcan_bridge_node.hpp
+++ b/include/nobleo_socketcan_bridge/socketcan_bridge_node.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "nobleo_socketcan_bridge/socketcan_bridge.hpp"
 #include "rclcpp/node.hpp"
-#include "ros2_socketcan_bridge/socketcan_bridge.hpp"
 
-namespace ros2_socketcan_bridge
+namespace nobleo_socketcan_bridge
 {
 class SocketCanBridgeNode : public rclcpp::Node
 {
@@ -19,4 +19,4 @@ private:
   SocketCanBridge bridge;
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr can_sub;
 };
-}  // namespace ros2_socketcan_bridge
+}  // namespace nobleo_socketcan_bridge

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <package format="3">
-  <name>ros2_socketcan_bridge</name>
+  <name>nobleo_socketcan_bridge</name>
   <version>0.0.0</version>
   <description>Simple wrapper around SocketCAN</description>
   <maintainer email="ramon.wijnands@nobleo.nl">Ramon Wijnands</maintainer>

--- a/src/socketcan_bridge.cpp
+++ b/src/socketcan_bridge.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ros2_socketcan_bridge/socketcan_bridge.hpp"
+#include "nobleo_socketcan_bridge/socketcan_bridge.hpp"
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>
@@ -15,7 +15,7 @@
 
 #include "rclcpp/logging.hpp"
 
-namespace ros2_socketcan_bridge
+namespace nobleo_socketcan_bridge
 {
 std::ostream & operator<<(std::ostream & os, const can_msgs::msg::Frame & msg)
 {
@@ -192,4 +192,4 @@ can_msgs::msg::Frame to_msg(const can_frame & frame)
   return msg;
 }
 
-}  // namespace ros2_socketcan_bridge
+}  // namespace nobleo_socketcan_bridge

--- a/src/socketcan_bridge_ee.cpp
+++ b/src/socketcan_bridge_ee.cpp
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "nobleo_socketcan_bridge/socketcan_bridge_node.hpp"
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
-#include "ros2_socketcan_bridge/socketcan_bridge_node.hpp"
 
-using ros2_socketcan_bridge::SocketCanBridgeNode;
+using nobleo_socketcan_bridge::SocketCanBridgeNode;
 
 int main(int argc, char * argv[])
 {

--- a/src/socketcan_bridge_node.cpp
+++ b/src/socketcan_bridge_node.cpp
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ros2_socketcan_bridge/socketcan_bridge_node.hpp"
+#include "nobleo_socketcan_bridge/socketcan_bridge_node.hpp"
 
 #include <rclcpp_components/register_node_macro.hpp>
 
-namespace ros2_socketcan_bridge
+namespace nobleo_socketcan_bridge
 {
 
 SocketCanBridgeNode::SocketCanBridgeNode(const rclcpp::NodeOptions & options)
@@ -21,5 +21,5 @@ SocketCanBridgeNode::SocketCanBridgeNode(const rclcpp::NodeOptions & options)
 {
 }
 
-}  // namespace ros2_socketcan_bridge
-RCLCPP_COMPONENTS_REGISTER_NODE(ros2_socketcan_bridge::SocketCanBridgeNode)
+}  // namespace nobleo_socketcan_bridge
+RCLCPP_COMPONENTS_REGISTER_NODE(nobleo_socketcan_bridge::SocketCanBridgeNode)

--- a/test/benchmark.launch.xml
+++ b/test/benchmark.launch.xml
@@ -9,11 +9,11 @@ SPDX-License-Identifier: Apache-2.0
 
     <executable cmd="ros2 topic pub -r $(var rate) -p $(var rate)0 /bridge1/tx can_msgs/msg/Frame '{}'"/>
 
-    <node name="bridge1" pkg="ros2_socketcan_bridge" exec="socketcan_bridge">
+    <node name="bridge1" pkg="nobleo_socketcan_bridge" exec="socketcan_bridge">
         <param name="interface" value="vcan0"/>
     </node>
 
-    <node name="bridge2" pkg="ros2_socketcan_bridge" exec="socketcan_bridge">
+    <node name="bridge2" pkg="nobleo_socketcan_bridge" exec="socketcan_bridge">
         <param name="interface" value="vcan0"/>
     </node>
 

--- a/test/comparison.launch.xml
+++ b/test/comparison.launch.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
     <executable cmd="ros2 topic pub -r $(var rate) -p $(var rate)0 /to_can_bus can_msgs/msg/Frame '{id: 1}'"/>
     <executable cmd="ros2 topic pub -r $(var rate) -p $(var rate)0 /socketcan_bridge/tx can_msgs/msg/Frame '{id: 2}'"/>
 
-    <node name="socketcan_bridge" pkg="ros2_socketcan_bridge" exec="$(var node)">
+    <node name="socketcan_bridge" pkg="nobleo_socketcan_bridge" exec="$(var node)">
         <param name="interface" value="vcan0"/>
     </node>
 

--- a/test/unittests.cpp
+++ b/test/unittests.cpp
@@ -5,10 +5,10 @@
 #include <gtest/gtest.h>
 #include <linux/can.h>
 
-#include "ros2_socketcan_bridge/socketcan_bridge.hpp"
+#include "nobleo_socketcan_bridge/socketcan_bridge.hpp"
 
-using ros2_socketcan_bridge::from_msg;
-using ros2_socketcan_bridge::to_msg;
+using nobleo_socketcan_bridge::from_msg;
+using nobleo_socketcan_bridge::to_msg;
 
 TEST(from_msg, standard)
 {


### PR DESCRIPTION
To make the package releasable, let's add organization prefix to the package name
https://github.com/ros/rosdistro/pull/41512