### PR TITLE
Disable clang_format on humble

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,7 @@ SPDX-License-Identifier: Apache-2.0
   <test_depend>ament_lint_auto</test_depend>
 
   <!-- Linters -->
-  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend condition="$ROS_DISTRO != humble">ament_cmake_clang_format</test_depend>
   <!-- <test_depend>ament_cmake_clang_tidy</test_depend> -->
   <!-- <test_depend>ament_cmake_copyright</test_depend> -->
   <test_depend>ament_cmake_cppcheck</test_depend>


### PR DESCRIPTION
This version of clang_format has a different output.