### PR TITLE
fix: make state_ atomic

### DIFF
--- a/include/nobleo_socketcan_bridge/socketcan_bridge.hpp
+++ b/include/nobleo_socketcan_bridge/socketcan_bridge.hpp
@@ -64,7 +64,7 @@ private:
   int socket_;
   CanCallback receive_callback_;
   std::jthread receive_thread_;
-  CanState state_;
+  std::atomic<CanState> state_;
 };
 
 can_frame from_msg(const can_msgs::msg::Frame & msg);


### PR DESCRIPTION
It is accessed from the main thread and updated via the receiver thread.